### PR TITLE
feat: add the key 'B' in normal and select

### DIFF
--- a/src/main/clojure/fominok/ideahelix/editor.clj
+++ b/src/main/clojure/fominok/ideahelix/editor.clj
@@ -289,6 +289,14 @@
         (-> (ihx-selection document caret)
             (ihx-word-backward! editor)
             (ihx-apply-selection! document))))
+    ((:shift \B)
+      "Select WORD backward" :scroll
+      [state document caret]
+
+      (dotimes [_ (get-prefix state)]
+        (-> (ihx-selection document caret)
+            (ihx-long-word-backward! document false)
+            (ihx-apply-selection! document))))
     ((:or \j KeyEvent/VK_DOWN)
      "Move carets down" :scroll
      [state document caret]
@@ -371,6 +379,13 @@
       (dotimes [_ (get-prefix state)]
         (-> (ihx-selection document caret)
             (ihx-word-backward-extending! editor)
+            (ihx-apply-selection! document))))
+    ((:shift \B)
+      "Select WORD backward extending" :scroll
+      [state editor document caret]
+      (dotimes [_ (get-prefix state)]
+        (-> (ihx-selection document caret)
+            (ihx-long-word-backward! document true)
             (ihx-apply-selection! document))))
     ((:or \j KeyEvent/VK_DOWN)
      "Move carets down extending" :scroll

--- a/src/main/clojure/fominok/ideahelix/editor/selection.clj
+++ b/src/main/clojure/fominok/ideahelix/editor/selection.clj
@@ -346,6 +346,26 @@
       (assoc new-selection :anchor (max 0 (dec (.getOffset caret))))
       new-selection)))
 
+(defn ihx-long-word-backward!
+  [{:keys [_ offset] :as selection} document extending?]
+  (let [text (-> (.getCharsSequence document) (.subSequence 0 offset) StringBuilder. .reverse)
+        blank-chars (set " \t\n\r")
+        len (.length text)
+        start (cond-> 1
+                (and
+                 (not (contains? blank-chars (.charAt text 0)))
+                 (contains? blank-chars (.charAt text 1)))
+                inc
+                (= \newline (.charAt text 1))
+                (+ 2))
+        sub (.subSequence text start len)
+        end-offset (+ start (or (find-next-occurrence sub {:pos #{\newline} :neg blank-chars}) (.length sub)))
+        sub (.subSequence text end-offset len)
+        end-offset (+ end-offset (or (find-next-occurrence sub {:pos blank-chars}) (.length sub)))
+        end-offset (dec end-offset)]
+    (if extending?
+      (assoc selection :offset (- offset end-offset 1))
+      (assoc selection :offset (- offset end-offset 1) :anchor (- offset start)))))
 
 (defn ihx-move-caret-line-n
   [editor document n]


### PR DESCRIPTION
add the key 'B' being go to previous word with only newline and space used as separator. For all the three PR that has been made, i use a custom logic instead of relying on java api. The api is probably made for vi mode and the logic must often be slightly different, using it would resolve in strange corner case