### PR TITLE
feat: match delete

### DIFF
--- a/src/main/clojure/fominok/ideahelix/editor.clj
+++ b/src/main/clojure/fominok/ideahelix/editor.clj
@@ -325,7 +325,10 @@
      (do (-> (ihx-move-caret-line-n editor document (get-prefix state))
              ihx-shrink-selection
              (ihx-apply-selection! document))
-         (assoc state :mode :normal))))
+         (assoc state :mode :normal)))
+   (\m
+     "Match menu"
+     [state] (assoc state :mode :match)))
 
   (:select
     (\g
@@ -403,7 +406,10 @@
      [state editor document]
      (do (-> (ihx-move-caret-line-n editor document (get-prefix state))
              (ihx-apply-selection! document))
-         (assoc state :mode :select))))
+         (assoc state :mode :select)))
+   (\m
+     "Match menu"
+     [state] (assoc state :mode :select-match)))
 
   (:goto
     (Character/isDigit
@@ -555,8 +561,19 @@
        (when-let [^LookupImpl lookup (LookupManager/getActiveLookup editor)]
          (.setSelectedIndex lookup (dec (.getSelectedIndex lookup)))
          state)))
-    (_ [state] (assoc state :pass true))))
+    (_ [state] (assoc state :pass true)))
 
+  ((:or :match :select-match)
+   (\d
+    [state] (assoc state :mode :match-surround-delete)))
+  
+  (:match-surround-delete
+   (_
+    "Surround delete" :write
+    [project state document caret char]
+     (-> (ihx-selection document caret)
+         (ihx-surround-delete document char)
+         (ihx-apply-selection! document)))))
 
 (defn handle-editor-event
   [project ^EditorImpl editor ^KeyEvent event]

--- a/src/main/clojure/fominok/ideahelix/editor.clj
+++ b/src/main/clojure/fominok/ideahelix/editor.clj
@@ -276,12 +276,12 @@
             (ihx-word-forward! editor)
             (ihx-apply-selection! document))))
     ((:shift \W)
-      "Select WORD forward" :scroll
-      [state editor document caret]
-      (dotimes [_ (get-prefix state)]
-        (-> (ihx-selection document caret)
-            (ihx-long-word-forward! document false)
-            (ihx-apply-selection! document))))
+     "Select WORD forward" :scroll
+     [state editor document caret]
+     (dotimes [_ (get-prefix state)]
+       (-> (ihx-selection document caret)
+           (ihx-long-word-forward! document false)
+           (ihx-apply-selection! document))))
     (\e
       "Select word end" :scroll
       [state editor document caret]
@@ -304,13 +304,13 @@
             (ihx-word-backward! editor)
             (ihx-apply-selection! document))))
     ((:shift \B)
-      "Select WORD backward" :scroll
-      [state document caret]
+     "Select WORD backward" :scroll
+     [state document caret]
 
-      (dotimes [_ (get-prefix state)]
-        (-> (ihx-selection document caret)
-            (ihx-long-word-backward! document false)
-            (ihx-apply-selection! document))))
+     (dotimes [_ (get-prefix state)]
+       (-> (ihx-selection document caret)
+           (ihx-long-word-backward! document false)
+           (ihx-apply-selection! document))))
     ((:or \j KeyEvent/VK_DOWN)
      "Move carets down" :scroll
      [state document caret]
@@ -399,12 +399,12 @@
             (ihx-word-forward-extending! editor)
             (ihx-apply-selection! document))))
     ((:shift \W)
-      "Select WORD forward extending" :scroll
-      [state editor document caret]
-      (dotimes [_ (get-prefix state)]
-        (-> (ihx-selection document caret)
-            (ihx-long-word-forward! document true)
-            (ihx-apply-selection! document))))
+     "Select WORD forward extending" :scroll
+     [state editor document caret]
+     (dotimes [_ (get-prefix state)]
+       (-> (ihx-selection document caret)
+           (ihx-long-word-forward! document true)
+           (ihx-apply-selection! document))))
     (\e
       "Select word end extending" :scroll
       [state document editor caret]
@@ -427,12 +427,12 @@
             (ihx-word-backward-extending! editor)
             (ihx-apply-selection! document))))
     ((:shift \B)
-      "Select WORD backward extending" :scroll
-      [state editor document caret]
-      (dotimes [_ (get-prefix state)]
-        (-> (ihx-selection document caret)
-            (ihx-long-word-backward! document true)
-            (ihx-apply-selection! document))))
+     "Select WORD backward extending" :scroll
+     [state editor document caret]
+     (dotimes [_ (get-prefix state)]
+       (-> (ihx-selection document caret)
+           (ihx-long-word-backward! document true)
+           (ihx-apply-selection! document))))
     ((:or \j KeyEvent/VK_DOWN)
      "Move carets down extending" :scroll
      [state document caret]
@@ -637,14 +637,14 @@
   ((:or :match :select-match)
    (\d
     [state] (assoc state :mode :match-surround-delete)))
-  
+
   (:match-surround-delete
    (_
     "Surround delete" :write
     [project state document caret char]
-     (-> (ihx-selection document caret)
-         (ihx-surround-delete document char)
-         (ihx-apply-selection! document)))))
+    (-> (ihx-selection document caret)
+        (ihx-surround-delete document char)
+        (ihx-apply-selection! document))))
 
   (:match
    (\m

--- a/src/main/clojure/fominok/ideahelix/editor/util.clj
+++ b/src/main/clojure/fominok/ideahelix/editor/util.clj
@@ -34,3 +34,10 @@
   (let [editor-height-px (.. editor getScrollingModel getVisibleArea getHeight)
         line-height-px (.getLineHeight editor)]
     (int (quot editor-height-px line-height-px))))
+
+(defn printable-char? [c]
+  (let [block (java.lang.Character$UnicodeBlock/of c)]
+    (and (not (Character/isISOControl c))
+         (not= c java.awt.event.KeyEvent/CHAR_UNDEFINED)
+         (some? block)
+         (not= block java.lang.Character$UnicodeBlock/SPECIALS))))


### PR DESCRIPTION
Add the command md<char> to delete a surrounding char. Like for match-surround it doesn't go back to normal as I didn't see a way to do that after some time of research