### PR TITLE
feat: match-inside/around

### DIFF
--- a/src/main/clojure/fominok/ideahelix/editor.clj
+++ b/src/main/clojure/fominok/ideahelix/editor.clj
@@ -325,7 +325,10 @@
      (do (-> (ihx-move-caret-line-n editor document (get-prefix state))
              ihx-shrink-selection
              (ihx-apply-selection! document))
-         (assoc state :mode :normal))))
+         (assoc state :mode :normal)))
+   (\m
+     "Match menu"
+     [state] (assoc state :mode :match)))
 
   (:select
     (\g
@@ -403,7 +406,10 @@
      [state editor document]
      (do (-> (ihx-move-caret-line-n editor document (get-prefix state))
              (ihx-apply-selection! document))
-         (assoc state :mode :select))))
+         (assoc state :mode :select)))
+   (\m
+     "Match menu"
+     [state] (assoc state :mode :select-match)))
 
   (:goto
     (Character/isDigit
@@ -555,8 +561,55 @@
        (when-let [^LookupImpl lookup (LookupManager/getActiveLookup editor)]
          (.setSelectedIndex lookup (dec (.getSelectedIndex lookup)))
          state)))
-    (_ [state] (assoc state :pass true))))
+    (_ [state] (assoc state :pass true)))
 
+  (:match
+   (\i
+    [state] (assoc state :mode :match-inside))
+   (\a
+    [state] (assoc state :mode :match-around)))
+
+  (:select-match
+   (\i
+    [state] (assoc state :mode :select-match-inside))
+   (\a
+    [state] (assoc state :mode :select-match-around)))
+
+  (:match-inside
+   (_
+    "Select inside"
+    [project state document caret char]
+     (-> (ihx-selection document caret)
+         (ihx-select-inside document char)
+         (ihx-apply-selection! document))
+    [state] (assoc state :mode :normal)))
+
+  (:select-match-inside
+   (_
+    "Select inside"
+    [project state document caret char]
+     (-> (ihx-selection document caret)
+         (ihx-select-inside document char)
+         (ihx-apply-selection! document))
+    [state] (assoc state :mode :select)))
+
+  (:match-around
+   (_
+    "Select around"
+    [project state document caret char]
+     (-> (ihx-selection document caret)
+         (ihx-select-around document char)
+         (ihx-apply-selection! document))
+    [state] (assoc state :mode :normal)))
+
+  (:select-match-around
+   (_
+    "Select around"
+    [project state document caret char]
+     (-> (ihx-selection document caret)
+         (ihx-select-around document char)
+         (ihx-apply-selection! document))
+    [state] (assoc state :mode :select))))
 
 (defn handle-editor-event
   [project ^EditorImpl editor ^KeyEvent event]

--- a/src/main/clojure/fominok/ideahelix/editor/util.clj
+++ b/src/main/clojure/fominok/ideahelix/editor/util.clj
@@ -34,3 +34,10 @@
   (let [editor-height-px (.. editor getScrollingModel getVisibleArea getHeight)
         line-height-px (.getLineHeight editor)]
     (int (quot editor-height-px line-height-px))))
+
+(defn printable-char? [c]
+  (let [block (java.lang.Character$UnicodeBlock/of c)]
+    (and (not (Character/isISOControl c))
+         (not= c java.awt.event.KeyEvent/CHAR_UNDEFINED)
+         (some? block)
+         (not= block java.lang.Character$UnicodeBlock/SPECIALS))))


### PR DESCRIPTION
Add the commands mi<char> and ma<char> to select between characters. With the others 3 PR I think we have a very solid match mode. I will probably make the command match-replace in a few days.