### PR TITLE
feat: Match replace

### DIFF
--- a/src/main/clojure/fominok/ideahelix/editor.clj
+++ b/src/main/clojure/fominok/ideahelix/editor.clj
@@ -107,12 +107,12 @@
    (\u
      "Undo"
      [editor] (actions editor IdeActions/ACTION_UNDO)
-     [document caret] (-> (ihx-selection document caret)
+     [document editor caret] (-> (ihx-selection document caret)
                           (ihx-apply-selection! document)))
    ((:shift \U)
     "Redo"
     [editor] (actions editor IdeActions/ACTION_REDO)
-    [document caret] (-> (ihx-selection document caret)
+    [document editor caret] (-> (ihx-selection document caret)
                          (ihx-apply-selection! document)))
    (\y
      "Yank"
@@ -161,7 +161,7 @@
      (replace-selections state project editor document))
    (\a
      "Append to selections"
-     [document caret]
+     [document editor caret]
      (-> (ihx-selection document caret)
          ihx-make-forward
          (ihx-apply-selection! document))
@@ -180,7 +180,7 @@
     (into-insert-mode project state editor))
    (\i
      "Prepend to selections"
-     [document caret]
+     [document editor caret]
      (-> (ihx-selection document caret)
          ihx-make-backward
          (ihx-apply-selection! document))
@@ -197,18 +197,18 @@
     (into-insert-mode project state editor))
    ((:or (:alt \;) (:alt \u2026))
     "Flip selection" :scroll
-    [document caret] (-> (ihx-selection document caret)
+    [document editor caret] (-> (ihx-selection document caret)
                          flip-selection
                          (ihx-apply-selection! document)))
    ((:or (:alt \:) (:alt \u00DA))
     "Make selections forward"
-    [document caret]
+    [document editor caret]
     (-> (ihx-selection document caret)
         ihx-make-forward
         (ihx-apply-selection! document)))
    (\;
      "Shrink selections to 1 char"
-     [document caret]
+     [document editor caret]
      (-> (ihx-selection document caret)
          ihx-shrink-selection
          (ihx-apply-selection! document)))
@@ -291,7 +291,7 @@
             (ihx-apply-selection! document))))
     ((:shift \E)
      "Select WORD end" :scroll
-     [state document caret]
+     [state document editor caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-long-word-end! document false)
@@ -305,7 +305,7 @@
             (ihx-apply-selection! document))))
     ((:shift \B)
      "Select WORD backward" :scroll
-     [state document caret]
+     [state document editor caret]
 
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
@@ -313,7 +313,7 @@
            (ihx-apply-selection! document))))
     ((:or \j KeyEvent/VK_DOWN)
      "Move carets down" :scroll
-     [state document caret]
+     [state document editor caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-move-relative! :lines 1)
@@ -321,7 +321,7 @@
            (ihx-apply-selection-preserving document))))
     ((:or \k KeyEvent/VK_UP)
      "Move carets up" :scroll
-     [state document caret]
+     [state document editor caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-move-relative! :lines -1)
@@ -329,14 +329,14 @@
            (ihx-apply-selection-preserving document))))
     ((:or \h KeyEvent/VK_LEFT)
      "Move carets left" :scroll
-     [state document caret]
+     [state document editor caret]
      (-> (ihx-selection document caret)
          (ihx-move-backward (get-prefix state))
          ihx-shrink-selection
          (ihx-apply-selection! document)))
     ((:or \l KeyEvent/VK_RIGHT)
      "Move carets right" :scroll
-     [state document caret]
+     [state document editor caret]
      (-> (ihx-selection document caret)
          (ihx-move-forward (get-prefix state))
          ihx-shrink-selection
@@ -435,27 +435,27 @@
            (ihx-apply-selection! document))))
     ((:or \j KeyEvent/VK_DOWN)
      "Move carets down extending" :scroll
-     [state document caret]
+     [state document editor caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-move-relative! :lines 1)
            (ihx-apply-selection-preserving document))))
     ((:or \k KeyEvent/VK_UP)
      "Move carets up extending" :scroll
-     [state document caret]
+     [state document editor caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-move-relative! :lines -1)
            (ihx-apply-selection-preserving document))))
     ((:or \h KeyEvent/VK_LEFT)
      "Move carets left extending" :scroll
-     [state document caret]
+     [state document editor caret]
      (-> (ihx-selection document caret)
          (ihx-move-backward (get-prefix state))
          (ihx-apply-selection! document)))
     ((:or \l KeyEvent/VK_RIGHT)
      "Move carets right extending" :scroll
-     [state document caret]
+     [state document editor caret]
      (-> (ihx-selection document caret)
          (ihx-move-forward (get-prefix state))
          (ihx-apply-selection! document)))
@@ -611,7 +611,7 @@
     ((:or \w (:ctrl \u0017))
      "Switch split"
      [editor] (actions editor "NextSplitter")
-     [state] (assoc state :mode :normal))
+      [state] (assoc state :mode :normal))
     (\o
       [editor] (actions editor "UnsplitAll")
       [state] (assoc state :mode :normal))
@@ -684,28 +684,11 @@
 
   ((:or :match :select-match)
    (\s
-     [state] (assoc state :mode :match-surround-add)))
-
-  (:match-surround-add
-    (_
-      "Surround add" :write
-      [project state document caret char]
-      (-> (ihx-selection document caret)
-          (ihx-surround-add document char)
-          (ihx-apply-selection! document))))
-
-  ((:or :match :select-match)
+     [state] (assoc state :mode :match-surround-add))
    (\d
-     [state] (assoc state :mode :match-surround-delete)))
-
-  (:match-surround-delete
-    (_
-      "Surround delete" :write
-      [project document caret char]
-      (-> (ihx-selection document caret)
-          (ihx-surround-delete document char)
-          (ihx-apply-selection! document))
-      [state] (assoc state :mode :normal)))
+     [state] (assoc state :mode :match-surround-delete))
+   (\r
+     [state] (assoc state :mode :match-find)))
 
   (:match
     (\m
@@ -720,11 +703,40 @@
   (:select-match
     (\m
       "Goto matching bracket"
-      [project document editor caret]
+      [document editor caret]
       (-> (ihx-selection document caret)
           (ihx-goto-matching document)
           (ihx-apply-selection! document))
-      [state] (assoc state :mode :select))))
+      [state] (assoc state :mode :select)))
+
+  (:match-surround-add
+    (_
+      "Surround add" :write
+      [project state document editor caret char]
+      (-> (ihx-selection document caret)
+          (ihx-surround-add document char)
+          (ihx-apply-selection! document))))
+
+  (:match-surround-delete
+    (_
+      "Surround delete" :write
+      [document editor caret char]
+      (-> (ihx-selection document caret)
+          (ihx-surround-delete document char)
+          (ihx-apply-selection! document))
+      [state] (assoc state :mode :normal)))
+
+  (:match-find
+    (_
+      "Find the matching brackets"
+      [state editor document char]
+      (ihx-surround-find state editor document char)))
+
+  (:match-replace
+    (_
+      "Replace the matching brackets" :write
+      [state editor document char]
+      (ihx-surround-replace state editor document char))))
 
 
 (defn handle-editor-event

--- a/src/main/clojure/fominok/ideahelix/editor.clj
+++ b/src/main/clojure/fominok/ideahelix/editor.clj
@@ -108,13 +108,13 @@
    (\u
      "Undo"
      [editor] (actions editor IdeActions/ACTION_UNDO)
-     [document editor caret] (-> (ihx-selection document caret)
-                                 (ihx-apply-selection! document)))
+     [document caret] (-> (ihx-selection document caret)
+                          (ihx-apply-selection! document)))
    ((:shift \U)
     "Redo"
     [editor] (actions editor IdeActions/ACTION_REDO)
-    [document editor caret] (-> (ihx-selection document caret)
-                                (ihx-apply-selection! document)))
+    [document caret] (-> (ihx-selection document caret)
+                         (ihx-apply-selection! document)))
    (\y
      "Yank"
      [state editor document]
@@ -162,7 +162,7 @@
      (replace-selections state project editor document))
    (\a
      "Append to selections"
-     [document editor caret]
+     [document caret]
      (-> (ihx-selection document caret)
          ihx-make-forward
          (ihx-apply-selection! document))
@@ -181,7 +181,7 @@
     (into-insert-mode project state editor))
    (\i
      "Prepend to selections"
-     [document editor caret]
+     [document caret]
      (-> (ihx-selection document caret)
          ihx-make-backward
          (ihx-apply-selection! document))
@@ -198,18 +198,18 @@
     (into-insert-mode project state editor))
    ((:or (:alt \;) (:alt \u2026))
     "Flip selection" :scroll
-    [document editor caret] (-> (ihx-selection document caret)
-                                flip-selection
-                                (ihx-apply-selection! document)))
+    [document caret] (-> (ihx-selection document caret)
+                         flip-selection
+                         (ihx-apply-selection! document)))
    ((:or (:alt \:) (:alt \u00DA))
     "Make selections forward"
-    [document editor caret]
+    [document caret]
     (-> (ihx-selection document caret)
         ihx-make-forward
         (ihx-apply-selection! document)))
    (\;
      "Shrink selections to 1 char"
-     [document editor caret]
+     [document caret]
      (-> (ihx-selection document caret)
          ihx-shrink-selection
          (ihx-apply-selection! document)))
@@ -292,7 +292,7 @@
             (ihx-apply-selection! document))))
     ((:shift \E)
      "Select WORD end" :scroll
-     [state document editor caret]
+     [state document caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-long-word-end! document false)
@@ -306,15 +306,14 @@
             (ihx-apply-selection! document))))
     ((:shift \B)
      "Select WORD backward" :scroll
-     [state document editor caret]
-
+     [state document caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-long-word-backward! document false)
            (ihx-apply-selection! document))))
     ((:or \j KeyEvent/VK_DOWN)
      "Move carets down" :scroll
-     [state document editor caret]
+     [state document caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-move-relative! :lines 1)
@@ -322,7 +321,7 @@
            (ihx-apply-selection-preserving document))))
     ((:or \k KeyEvent/VK_UP)
      "Move carets up" :scroll
-     [state document editor caret]
+     [state document caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-move-relative! :lines -1)
@@ -330,14 +329,14 @@
            (ihx-apply-selection-preserving document))))
     ((:or \h KeyEvent/VK_LEFT)
      "Move carets left" :scroll
-     [state document editor caret]
+     [state document caret]
      (-> (ihx-selection document caret)
          (ihx-move-backward (get-prefix state))
          ihx-shrink-selection
          (ihx-apply-selection! document)))
     ((:or \l KeyEvent/VK_RIGHT)
      "Move carets right" :scroll
-     [state document editor caret]
+     [state document caret]
      (-> (ihx-selection document caret)
          (ihx-move-forward (get-prefix state))
          ihx-shrink-selection
@@ -436,27 +435,27 @@
            (ihx-apply-selection! document))))
     ((:or \j KeyEvent/VK_DOWN)
      "Move carets down extending" :scroll
-     [state document editor caret]
+     [state document caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-move-relative! :lines 1)
            (ihx-apply-selection-preserving document))))
     ((:or \k KeyEvent/VK_UP)
      "Move carets up extending" :scroll
-     [state document editor caret]
+     [state document caret]
      (dotimes [_ (get-prefix state)]
        (-> (ihx-selection document caret)
            (ihx-move-relative! :lines -1)
            (ihx-apply-selection-preserving document))))
     ((:or \h KeyEvent/VK_LEFT)
      "Move carets left extending" :scroll
-     [state document editor caret]
+     [state document caret]
      (-> (ihx-selection document caret)
          (ihx-move-backward (get-prefix state))
          (ihx-apply-selection! document)))
     ((:or \l KeyEvent/VK_RIGHT)
      "Move carets right extending" :scroll
-     [state document editor caret]
+     [state document caret]
      (-> (ihx-selection document caret)
          (ihx-move-forward (get-prefix state))
          (ihx-apply-selection! document)))
@@ -648,7 +647,7 @@
   (:match-inside
     (_
       "Select inside"
-      [project state document caret char]
+      [document caret char]
       (-> (ihx-selection document caret)
           (ihx-select-inside document char)
           (ihx-apply-selection! document))
@@ -657,7 +656,7 @@
   (:select-match-inside
     (_
       "Select inside"
-      [project state document caret char]
+      [document caret char]
       (-> (ihx-selection document caret)
           (ihx-select-inside document char)
           (ihx-apply-selection! document))
@@ -666,7 +665,7 @@
   (:match-around
     (_
       "Select around"
-      [project state document caret char]
+      [document caret char]
       (-> (ihx-selection document caret)
           (ihx-select-around document char)
           (ihx-apply-selection! document))
@@ -675,7 +674,7 @@
   (:select-match-around
     (_
       "Select around"
-      [project state document caret char]
+      [document caret char]
       (-> (ihx-selection document caret)
           (ihx-select-around document char)
           (ihx-apply-selection! document))))
@@ -691,7 +690,7 @@
   (:match
     (\m
       "Goto matching bracket"
-      [project document editor caret]
+      [document caret]
       (-> (ihx-selection document caret)
           (ihx-goto-matching document)
           ihx-shrink-selection
@@ -701,7 +700,7 @@
   (:select-match
     (\m
       "Goto matching bracket"
-      [document editor caret]
+      [document caret]
       (-> (ihx-selection document caret)
           (ihx-goto-matching document)
           (ihx-apply-selection! document))
@@ -710,7 +709,7 @@
   (:match-surround-add
     (_
       "Surround add" :write
-      [project state document editor caret char]
+      [document caret char]
       (-> (ihx-selection document caret)
           (ihx-surround-add document char)
           (ihx-apply-selection! document))))
@@ -718,7 +717,7 @@
   (:match-surround-delete
     (_
       "Surround delete" :write
-      [document editor caret char]
+      [document caret char]
       (-> (ihx-selection document caret)
           (ihx-surround-delete document char)
           (ihx-apply-selection! document))

--- a/src/main/clojure/fominok/ideahelix/editor.clj
+++ b/src/main/clojure/fominok/ideahelix/editor.clj
@@ -712,7 +712,8 @@
       [document caret char]
       (-> (ihx-selection document caret)
           (ihx-surround-add document char)
-          (ihx-apply-selection! document))))
+          (ihx-apply-selection! document))
+      [state] (assoc state :mode :normal)))
 
   (:match-surround-delete
     (_

--- a/src/main/clojure/fominok/ideahelix/editor.clj
+++ b/src/main/clojure/fominok/ideahelix/editor.clj
@@ -109,12 +109,12 @@
      "Undo"
      [editor] (actions editor IdeActions/ACTION_UNDO)
      [document editor caret] (-> (ihx-selection document caret)
-                          (ihx-apply-selection! document)))
+                                 (ihx-apply-selection! document)))
    ((:shift \U)
     "Redo"
     [editor] (actions editor IdeActions/ACTION_REDO)
     [document editor caret] (-> (ihx-selection document caret)
-                         (ihx-apply-selection! document)))
+                                (ihx-apply-selection! document)))
    (\y
      "Yank"
      [state editor document]
@@ -199,8 +199,8 @@
    ((:or (:alt \;) (:alt \u2026))
     "Flip selection" :scroll
     [document editor caret] (-> (ihx-selection document caret)
-                         flip-selection
-                         (ihx-apply-selection! document)))
+                                flip-selection
+                                (ihx-apply-selection! document)))
    ((:or (:alt \:) (:alt \u00DA))
     "Make selections forward"
     [document editor caret]
@@ -609,7 +609,7 @@
     ((:or \w (:ctrl \u0017))
      "Switch split"
      [editor] (actions editor "NextSplitter")
-      [state] (assoc state :mode :normal))
+     [state] (assoc state :mode :normal))
     (\o
       [editor] (actions editor "UnsplitAll")
       [state] (assoc state :mode :normal))

--- a/src/main/clojure/fominok/ideahelix/editor/selection.clj
+++ b/src/main/clojure/fominok/ideahelix/editor/selection.clj
@@ -85,7 +85,7 @@
         (cond
           is-broken offset
           is-forward start
-          :default (max 0 (dec end)))]
+          :else (max 0 (dec end)))]
     (->IhxSelection caret anchor offset in-append)))
 
 
@@ -249,7 +249,7 @@
                 "select:"
                 "Select in selections"
                 (Messages/getQuestionIcon))
-        pattern (when (not (empty? input)) (re-pattern input))
+        pattern (when (seq input) (re-pattern input))
         matches
         (and pattern
              (->> (.getAllCarets model)
@@ -506,15 +506,16 @@
 (defn next-match
   [text offset opener target]
   (loop [to-find 1 text (.subSequence text offset (.length text)) acc-offset offset]
-    (let [target-offset (find-next-occurrence text {:pos (set [opener target])})
-          found (.charAt text target-offset)
-          text (.subSequence text (inc target-offset) (.length text))
-          acc-offset (inc acc-offset)]
-      (if (= found target) ; must check first if we found match in case match = char
-        (if (= to-find 1)
-          (+ acc-offset target-offset -1)
-          (recur (dec to-find) text (+ acc-offset target-offset)))
-        (recur (inc to-find) text (+ acc-offset target-offset))))))
+    (let [target-offset (find-next-occurrence text {:pos (set [opener target])})]
+      (when target-offset
+        (let [found (.charAt text target-offset)
+              text (.subSequence text (inc target-offset) (.length text))
+              acc-offset (+ acc-offset target-offset 1)]
+          (if (= found target)
+            (if (= to-find 1)
+              (dec acc-offset)
+              (recur (dec to-find) text acc-offset))
+            (recur (inc to-find) text acc-offset)))))))
 
 
 (defn previous-match
@@ -523,7 +524,7 @@
         idx (- len offset 1)
         text (-> (StringBuilder. text) .reverse)
         res (next-match text idx opener target)]
-    (- len res 1)))
+    (when res (- len res 1))))
 
 
 (defn get-open-close-chars
@@ -616,3 +617,75 @@
                      :open (next-match text (inc offset) opener match)
                      :close (previous-match text (dec offset) opener match))]
         (assoc selection :offset offset)))))
+
+
+(defn- find-bracket-pair
+  "Finds left and right bracket positions for the given offset, text, and chars."
+  [text offset open-char close-char]
+  (when-let [curr-char (and (< offset (count text)) (.charAt text offset))]
+    (let [pair (if (and (not= open-char curr-char) (not= close-char curr-char))
+                 [(previous-match text offset close-char open-char)
+                  (next-match text offset open-char close-char)]
+                 (cond
+                   (= open-char curr-char) [offset (next-match text (inc offset) open-char close-char)]
+                   (= close-char curr-char) [(previous-match text (dec offset) close-char open-char) offset]))]
+      (when (and (first pair) (second pair))
+        pair))))
+
+
+(defn- add-caret-at
+  "Adds a caret at the given offset (or uses primary if specified), sets single-char selection."
+  [model editor offset use-primary?]
+  (let [caret (if use-primary?
+                (.getPrimaryCaret model)
+                (.addCaret model (.offsetToVisualPosition editor offset) false))]
+    (when caret
+      (.setSelection caret offset (inc offset))
+      (.moveToOffset caret offset))))
+
+(defn ihx-surround-find
+  [state editor document char]
+  (if-not (printable-char? char)
+    state
+    (let [model (.getCaretModel editor)
+          original-carets (.getAllCarets model)
+          original-selections (mapv #(ihx-selection document % :insert-mode false) original-carets)
+          text (.getCharsSequence document)
+          {:keys [open-char close-char]} (get-open-close-chars char)
+          finder (fn [acc sel]
+                   (let [pair (find-bracket-pair text (:offset sel) open-char close-char)]
+                     (if pair (conj acc pair) acc)))
+          pairs (reduce finder [] original-selections)]
+      (if (empty? pairs)
+        (assoc state :mode :normal)
+        (do
+          (.removeSecondaryCarets model)
+          (loop [remaining-pairs pairs
+                 is-first? true]
+            (when-let [[left right] (first remaining-pairs)]
+              (add-caret-at model editor left is-first?)
+              (add-caret-at model editor right false)
+              (recur (rest remaining-pairs) false)))
+          (assoc state :pre-match-selections original-selections
+                       :match-pairs pairs
+                       :mode :match-replace))))))
+
+(defn ihx-surround-replace
+  [state editor document char]
+  (if-not (printable-char? char)
+    state
+    (let [{:keys [open-char close-char]} (get-open-close-chars char)
+          pairs (:match-pairs state)
+          model (.getCaretModel editor)]
+      (when (seq pairs)
+        (doseq [[left right] pairs]
+          (.replaceString document left (inc left) (str open-char))
+          (.replaceString document right (inc right) (str close-char)))
+        (.removeSecondaryCarets model)
+        (doseq [[idx sel] (map-indexed vector (:pre-match-selections state))]
+          (let [caret (if (zero? idx)
+                        (.getPrimaryCaret model)
+                        (.addCaret model (.offsetToVisualPosition editor (:offset sel)) false))]
+            (when caret
+              (ihx-apply-selection! (assoc sel :caret caret) document)))))
+      (assoc state :mode :normal :pre-match-selections nil :match-pairs nil))))

--- a/src/main/clojure/fominok/ideahelix/editor/selection.clj
+++ b/src/main/clojure/fominok/ideahelix/editor/selection.clj
@@ -646,6 +646,7 @@
       (.setSelection caret offset (inc offset))
       (.moveToOffset caret offset))))
 
+
 (defn ihx-surround-find
   [state editor document char]
   (if-not (printable-char? char)
@@ -670,8 +671,9 @@
               (add-caret-at model editor right false)
               (recur (rest remaining-pairs) false)))
           (assoc state :pre-match-selections original-selections
-                       :match-pairs pairs
-                       :mode :match-replace))))))
+                 :match-pairs pairs
+                 :mode :match-replace))))))
+
 
 (defn ihx-surround-replace
   [state editor document char]


### PR DESCRIPTION
This PR adds the last command for match mode `mr`. The `mi/ma` command is still missing some subcommands. It supports multicaret and allows replacing a surrounding with any character.